### PR TITLE
Remove deprecated api keys

### DIFF
--- a/app/src/debug/res/values/google_maps_api.xml
+++ b/app/src/debug/res/values/google_maps_api.xml
@@ -20,5 +20,5 @@
     Once you have your key (it starts with "AIza"), replace the "google_maps_key"
     string in this file.
     -->
-    <string name="google_maps_key" templateMergeStrategy="preserve" translatable="false">AIzaSyDi6bwcjXVTpfS7YfnqZcLBvp7bJgOey1Q</string>
+    <string name="google_maps_key" templateMergeStrategy="preserve" translatable="false">PLACEHOLDER</string>
 </resources>

--- a/app/src/release/res/values/google_maps_api.xml
+++ b/app/src/release/res/values/google_maps_api.xml
@@ -16,5 +16,5 @@
     Once you have your key (it starts with "AIza"), replace the "google_maps_key"
     string in this file.
     -->
-    <string name="google_maps_key" templateMergeStrategy="preserve" translatable="false">YOUR_KEY_HERE</string>
+    <string name="google_maps_key" templateMergeStrategy="preserve" translatable="false">PLACEHOLDER</string>
 </resources>


### PR DESCRIPTION
Removes the deprecated google maps api key.
The new one has been shared on Discord.